### PR TITLE
feat: Implement sludge particle combination and damage scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ DV_Game is a 2D top-down arcade-style game where you control a heroic robot vacu
     *   The sword destroys sludge particles, granting you Experience Points (XP).
 *   **Sludge:**
     *   Sludge particles will actively move towards you.
-    *   If a sludge particle collides with your vacuum, you will lose one health point.
+    *   **Particle Combination:** Sludge particles can collide and combine with each other.
+        *   When particles combine, they form a single, larger sludge particle.
+        *   Larger particles are visually bigger and move slightly slower.
+    *   **Damage:** If a sludge particle collides with your vacuum, you will lose health.
+        *   The amount of damage taken is proportional to the size of the sludge particle – larger particles deal more damage!
+    *   **XP Value:** The XP gained from destroying a sludge particle with your sword is also proportional to its size.
 *   **Leveling Up:**
     *   Collect XP by destroying sludge with your sword.
     *   When you gain enough XP, you will level up, increasing the XP required for the next level.

--- a/cypress/e2e/game.cy.js
+++ b/cypress/e2e/game.cy.js
@@ -37,4 +37,114 @@ describe('Game Page E2E Tests', () => {
     });
     cy.window().its('isPaused').should('be.false');
   });
+
+  it('should combine two colliding particles into a larger one', () => {
+    cy.window().then(win => {
+      win.isPaused = true; // Pause the game
+      win.gameState.particles.length = 0; // Clear existing particles
+
+      // Create two particles very close to each other
+      // Radii: size 1 -> (1*2)+3 = 5.
+      // Particle 1 at (50,50)
+      // Particle 2 at (53,53) - their edges should overlap (50+5 > 53-5 is true for x, 5 > -2)
+      // Distance: sqrt((53-50)^2 + (53-50)^2) = sqrt(3^2 + 3^2) = sqrt(18) approx 4.24
+      // Sum of radii = 5 + 5 = 10. Since 4.24 < 10, they will collide.
+      win.createParticle(50, 50, 1); // Using direct args as per latest game.js
+      win.createParticle(53, 53, 1); // Using direct args
+    });
+
+    cy.window().its('gameState.particles').should('have.length', 2);
+
+    cy.window().then(win => {
+      win.isPaused = false; // Unpause
+    });
+
+    cy.wait(50); // Wait for a few game update cycles
+
+    cy.window().then(win => {
+      win.isPaused = true; // Pause again
+    });
+
+    cy.window().its('gameState.particles').should('have.length', 1);
+    cy.window().then(win => {
+      const particle = win.gameState.particles[0];
+      expect(particle.size).to.equal(2);
+      expect(particle.damage).to.equal(2);
+      expect(particle.radius).to.equal((2 * 2) + 3); // 7
+      expect(particle.xpValue).to.equal(2);
+    });
+  });
+
+  it('should deal more damage with a larger combined particle', () => {
+    let initialHealth;
+    let healthAfterSmallParticle;
+    const playerBuffer = 1; // To ensure particle is definitely overlapping player center
+
+    // Pause and setup
+    cy.window().then(win => {
+      win.isPaused = true;
+      initialHealth = win.gameState.player.health;
+      win.gameState.particles.length = 0; // Clear particles
+    });
+
+    // Scenario 1: Small particle damage
+    cy.window().then(win => {
+      // Create a size 1 particle on top of the player
+      win.createParticle(
+        win.gameState.player.x + win.gameState.player.width / 2,
+        win.gameState.player.y + win.gameState.player.height / 2,
+        1
+      );
+    });
+    cy.window().its('gameState.particles').should('have.length', 1);
+
+    cy.window().then(win => { win.isPaused = false; });
+    cy.wait(50); // Allow collision to happen
+    cy.window().then(win => { win.isPaused = true; });
+
+    cy.window().its('gameState.player.health').then(health => {
+      healthAfterSmallParticle = health;
+      expect(health).to.equal(initialHealth - 1); // Damage should be 1
+    });
+
+    // Reset for Scenario 2
+    cy.window().then(win => {
+      win.gameState.player.health = win.gameState.player.maxHealth; // Reset health
+      initialHealth = win.gameState.player.maxHealth; // Update initialHealth for next check
+      win.gameState.particles.length = 0; // Clear particles
+      
+      // Create two particles away from player to let them combine
+      // Radii: size 1 -> 5. Place them at (50,50) and (53,53)
+      win.createParticle(50, 50, 1);
+      win.createParticle(53, 53, 1);
+    });
+    cy.window().its('gameState.particles').should('have.length', 2);
+
+    cy.window().then(win => { win.isPaused = false; });
+    cy.wait(50); // Allow combination
+    cy.window().then(win => { win.isPaused = true; });
+
+    // Verify combination occurred
+    cy.window().its('gameState.particles').should('have.length', 1);
+    cy.window().then(win => {
+      const combinedParticle = win.gameState.particles[0];
+      expect(combinedParticle.size).to.equal(2);
+      expect(combinedParticle.damage).to.equal(2);
+
+      // Move combined particle onto player
+      combinedParticle.x = win.gameState.player.x + win.gameState.player.width / 2;
+      combinedParticle.y = win.gameState.player.y + win.gameState.player.height / 2;
+    });
+    
+    cy.window().then(win => { win.isPaused = false; });
+    cy.wait(50); // Allow collision
+    cy.window().then(win => { win.isPaused = true; });
+
+    cy.window().its('gameState.player.health').then(healthAfterCombinedParticle => {
+      expect(healthAfterCombinedParticle).to.equal(initialHealth - 2); // Damage should be 2
+      const damageFromSmall = initialHealth - healthAfterSmallParticle;
+      const damageFromCombined = initialHealth - healthAfterCombinedParticle;
+      expect(damageFromCombined).to.be.greaterThan(damageFromSmall);
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces new gameplay mechanics for sludge particles:

- Particles can now combine: When two sludge particles collide, they merge into a single, larger particle.
- Size and Damage Scaling: The size of the combined particle is the sum of the originals (up to a maximum size). Damage dealt by particles is now proportional to their size. Larger particles are also visually bigger and move slightly slower.
- XP Scaling: XP awarded for destroying particles is now proportional to their size.

The `game.js` file was updated to include:
- Modified particle object structure to include `size` and `damage`.
- Logic in the `update()` loop for detecting particle-particle collisions and handling combinations.
- Updated player-particle collision to use the particle's `damage` property.
- Exposed the full `particles` array to `window.gameState.particles` for better testability.

New E2E tests were added in `cypress/e2e/game.cy.js` to cover:
- Verification of particle combination, including the properties of the new combined particle.
- Confirmation that larger, combined particles deal increased damage to you compared to smaller ones.

Existing tests were reviewed and deemed unaffected by these changes.